### PR TITLE
Database for mister downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Please report issues in [the issue tracker for this repository][issues].
 
 Copy the `.mra` files in `/_Arcade/` and the `.rbf` file in `/_Arcade/cores/`. Then either run the `update_all.sh` script if you have it installed, or manually place the MAME ROM files (`nemesis.zip` merged, or both `nemesis.zip` and `nemesisuk.zip`, a.k.a. `nemesuk.zip`, split) in `/games/mame/`.
 
+### Installation using mister downloader
+
+Add the following to the bottom of `/media/fat/downloader.ini` on your MiSTer:
+
+```ini
+[GX400-Friends]
+db_url = https://raw.githubusercontent.com/GX400-Friends/gx400-bin/main/releases/gx400-friends.json
+```
+
+
 ## Credits
 
 * **LMN-san**

--- a/releases/gx400-friends.json
+++ b/releases/gx400-friends.json
@@ -1,0 +1,35 @@
+{
+    "db_id": "GX400-Friends",
+    "timestamp": 1647880787,
+    "files": {
+        "_Arcade/cores/nemesis_beta1_20220314.rbf": {
+            "hash": "ddcfc39e4475c96c8c709647a3f89100",
+            "size": 3815304,
+            "url": "https://raw.githubusercontent.com/GX400-Friends/gx400-bin/main/releases/nemesis_beta1_20220314.rbf",
+            "tags": [],
+            "overwrite": true,
+            "reboot": false
+        },
+        "_Arcade/Nemesis (UK).mra": {
+            "hash": "e75b1de487295f51bf633f4707416e67",
+            "size": 3980,
+            "url": "https://raw.githubusercontent.com/GX400-Friends/gx400-bin/main/releases/Nemesis%20(UK).mra",
+            "overwrite": true
+        },
+
+        "_Arcade/Nemesis (US).mra": {
+            "hash": "3ee2c95d633acab9036da2eb54e4cca0",
+            "size": 4062,
+            "url": "https://raw.githubusercontent.com/GX400-Friends/gx400-bin/main/releases/Nemesis%20(US).mra",
+            "overwrite": true
+        }
+    },
+    "folders": {
+        "_Arcade/": {
+            "tags": []
+        },
+        "_Arcade/cores": {
+            "tags": []
+        }
+    }
+}


### PR DESCRIPTION
Hello GX400 friends,

I was amazed by your Nemesis core beta and would like to help spread the word.

I have created a json file that can be used by the mister downloader tool to allow easy distribution.

If you want to try it on my fork just add to `/media/fat/downloader.ini` on your MiSTer the following lines:

```ini
[GX400-Friends]
db_url = https://raw.githubusercontent.com/willoucom/gx400-bin/main/releases/gx400-friends.json
```

After the merge the url will change, but i have added the new url in your README.md

Hope this will help you a little bit